### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supported OSF versions:
 - OSF4
 ## Installation
 
-Setting up a virutal environment and installing the current master:
+Setting up a virtual environment and installing the current master:
 
 Windows:
 
@@ -26,7 +26,7 @@ pip install .
 
 ## Usage
 
-Constructing a dataframe with the samples of two channels of a osf file:
+Constructing a dataframe with the samples of two channels of an OSF file:
 
 ```python
 from libosf import read_file

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python OSF Implementation 
+# Python OSF Implementation
 
 Package to read in data from OSF files.
 Supported OSF versions:
@@ -11,7 +11,6 @@ Setting up a virutal environment and installing the current master:
 Windows:
 
 ```powershell
-cd python-osf
 python -m venv venv
 .\venv\Scripts\activate
 pip install .
@@ -20,21 +19,20 @@ pip install .
 Linux:
 
 ```bash
-cd python-osf
 python -m venv venv
-. .\venv\bin\activate
+. ./venv/bin/activate
 pip install .
 ```
 
 ## Usage
 
-Constructing a dataframe with the samples of two Channels of a osf file:
+Constructing a dataframe with the samples of two channels of a osf file:
 
 ```python
 from libosf import read_file
 import pandas as pd
 
-channels = ['CAN_1', 'CAN_2']
+channels = ['System.CPU.Uptime', 'System.Device.AppUptime']
 
 with read_file('example.osf') as file:
     samples = file.get_samples(channels)
@@ -47,7 +45,7 @@ with read_file('example.osf') as file:
 ```
 
 
-## Examples 
+## Examples
 
 More examples showing how to use this package combined with numpy, pandas, matplotlib and more can be found under `./examples/`. 
 
@@ -55,23 +53,23 @@ Install dependencies before running:
 
 ```bash
 pip install .[examples]
-# generates an csv file with CAN_1 samples at python-osf4/output.csv
-python examples/to_csv.py -i input.osf -c CAN_1
+cd examples/
+# generates a csv file with samples of "System.CPU.Uptime" at example.csv
+python to_csv.py -i example.osf -c System.CPU.Uptime
 ```
+
 ## Common commands for development tasks
 
 ### Install editable development installation
 
-``` shell
+```shell
   # install local development version
-  cd libosf/
   pip install -e .
 ```
 
 ### Run unit tests
-``` shell
+```shell
   # install dependencies
-  cd libosf/
   pip install .[tests]
   # run python unit tests
   pytest
@@ -81,10 +79,12 @@ python examples/to_csv.py -i input.osf -c CAN_1
 
 ``` shell
   # install dependencies
-  cd libosf/
   pip install .[docs]
   # build the html documentation
-  cd docs
-  sphinx-build source/ build/ 
+  cd docs/
+  sphinx-build source/ build/html/
+
+  # Alternatively, if "make" is available:
+  make html
 ```
 


### PR DESCRIPTION
I fixed some mistakes in the README that helps new users to understand the repository easier.

Among others:
- Example channels were not present in `example.osf`. I arbitrarily selected `System.CPU.Uptime` and `System.Device.AppUptime` as examples.
- Some paths could be confusing.