### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ channels = ['System.CPU.Uptime', 'System.Device.AppUptime']
 with read_file('example.osf') as file:
     samples = file.get_samples(channels)
     data = {
-            'ts_n': samples[0],
-            'value': samples[1],
+            'value': samples[0],
+            'ts_n': samples[1],
             'ch_index': samples[2]
     }
     df = pd.DataFrame(data=data)

--- a/examples/numpy_example.py
+++ b/examples/numpy_example.py
@@ -10,7 +10,7 @@ OSF_FILE = EXAMPLE_DIR.joinpath("example.osf")
 
 def find_max():
     with libosf.read_file(OSF_FILE) as f:
-        samples: np.ndarray = np.array(f.get_samples(["Sine channel"]))
+        samples: np.ndarray = np.array(f.get_samples(["FuncGen.Sinus"]))
         print(f"length: {samples.shape[1]}")
 
     plt.plot((samples[1] / 1_000 ** 3).astype(np.datetime64), samples[0])


### PR DESCRIPTION
Hey,

just a small documentation change. The included snipped in the README suggested the timestamps were at index 0.
The current api returns the values at index 0.

Also the numpy example used a non existing channel name.